### PR TITLE
Fallback if converted text is empty

### DIFF
--- a/pattern.go
+++ b/pattern.go
@@ -26,15 +26,23 @@ func compilePatterns(from string, to string, cs map[caseName]struct{}) ([]*patte
 	return ps, nil
 }
 
+func fallback(f func(string) string, s string) string {
+	converted := f(s)
+	if len(converted) == 0 {
+		converted = s
+	}
+	return converted
+}
+
 func compilePattern(from string, to string, c *caseConfiguration) (*pattern, error) {
 	r, err := regexp.Compile(
 		compileDelimiter(c.head, true) +
-			c.convert(from) +
+			fallback(c.convert, from) +
 			compileDelimiter(c.tail, false),
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	return &pattern{r, "${1}" + c.convert(to) + "${2}"}, nil
+	return &pattern{r, "${1}" + fallback(c.convert, to) + "${2}"}, nil
 }


### PR DESCRIPTION
rnm break texts when the `to` can not be converted as expected.

```
rnm aurora オーロラ
```

```diff
diff --git a/command.go b/command.go
index 2426dba..400a6c7 100644
--- a/command.go
+++ b/command.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 
 	"github.com/go-git/go-billy/v5"
-	"github.com/logrusorgru/aurora/v3"
+	"github.com/logrusorgru//v3"
 )
 
 type command struct {
@@ -96,5 +96,5 @@ func (c *command) Run(ss []string) error {
 }
 
 func (c *command) printError(err error) {
-	fmt.Fprintln(c.stderr, aurora.Red(err))
+	fmt.Fprintln(c.stderr, .Red(err))
 }
diff --git a/go.mod b/go.mod
index a6198d3..d5d9559 100644
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,6 @@ require (
 	github.com/iancoleman/strcase v0.1.2
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jinzhu/inflection v1.0.0
-	github.com/logrusorgru/aurora/v3 v3.0.0
+	github.com/logrusorgru//v3 v3.0.0
 	github.com/stretchr/testify v1.6.1
 )
diff --git a/go.sum b/go.sum
index cd3bac5..f59fbba 100644
--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
-github.com/logrusorgru/aurora/v3 v3.0.0 h1:R6zcoZZbvVcGMvDCKo45A9U/lzYyzl5NfYIvznmDfE4=
-github.com/logrusorgru/aurora/v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
+github.com/logrusorgru//v3 v3.0.0 h1:R6zcoZZbvVcGMvDCKo45A9U/lzYyzl5NfYIvznmDfE4=
+github.com/logrusorgru//v3 v3.0.0/go.mod h1:vsR12bk5grlLvLXAYrBsb5Oc/N+LxAlxggSjiwMnCUc=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
diff --git a/main.go b/main.go
index ff342cb..b799dea 100644
--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/go-git/go-billy/v5/osfs"
-	"github.com/logrusorgru/aurora/v3"
+	"github.com/logrusorgru//v3"
 )
 
 func main() {
@@ -19,7 +19,7 @@ func main() {
 		os.Stderr,
 	).Run(os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stderr, aurora.Red(err))
+		fmt.Fprintln(os.Stderr, .Red(err))
 		os.Exit(1)
 	}
 }
```
